### PR TITLE
Refact: refine task 통일

### DIFF
--- a/dags/datapipline_culture.py
+++ b/dags/datapipline_culture.py
@@ -50,16 +50,9 @@ with DAG (
         trigger_rule="none_failed"
     )
 
-    # [refine data and pass df]
-    refine_data_s=PythonOperator(
-        task_id="refine_data_s",
-        python_callable=event_data,
-        trigger_rule="none_failed"
-    )
-
     # compare table
     read_event_table_=PythonOperator(
-        task_id="read_event_table",
+        task_id="read_event_table_",
         python_callable=postgreSQL("seoulmoa","datawarehouse","event").read_table
     )
 
@@ -195,6 +188,6 @@ with DAG (
     #         FROM numbered;
     #                  """)
     # make initial data
-    check_data_ >> get_event_data_ >> check_daily_ >> refine_data_ >> check_event_description_i_>> re_search_>> make_summary_ai_>> check_status_ >> save_to_event_
+    check_data_ >> get_event_data_ >> refine_data_ >> check_daily_ >> check_event_description_i_>> re_search_>> make_summary_ai_>> check_status_ >> save_to_event_
 
-    check_data_ >> get_event_data_ >> check_daily_ >> refine_data_s >> read_event_table_ >> check_event_description_s_>> re_search_ >> make_summary_ai_>> check_status_ >>save_to_sync_
+    check_data_ >> get_event_data_ >> refine_data_ >> check_daily_ >> read_event_table_ >> check_event_description_s_>> re_search_ >> make_summary_ai_>> check_status_ >>save_to_sync_

--- a/plugins/common/jobs/event_.py
+++ b/plugins/common/jobs/event_.py
@@ -76,10 +76,10 @@ def check_daily(**kwargs):
     ti = kwargs['ti']
     status = str(ti.xcom_pull(task_ids='check_data_',key='key'))
     if status == "init":
-        status = "refine_data_"
+        status = "check_event_description_i_"
     
     if status == "sync":
-        status = "refine_data_s"
+        status = "read_event_table_"
     return status
 
 def check_event_description(**kwargs) -> dict:


### PR DESCRIPTION
repository task instance 통일로 인한 task 획일화 가독성 증가
refine task를 하나로 두고, init 과 sync 에 따라 branch를 나누기 가능. task flow graph의 가독성 증가